### PR TITLE
『Nix入門』のサマリーに後編『Nix入門: ハンズオン編』のURLを追加

### DIFF
--- a/books/nix-introduction/config.yaml
+++ b/books/nix-introduction/config.yaml
@@ -4,7 +4,8 @@ summary: |
 
   Nixって何？と疑問に思っている方に向けて、Nixのコンセプトと仕組みを解説します。
 
-  後編: 『Nix入門: ハンズオン編』（現在執筆中・公開日未定）
+  後編: 『Nix入門: ハンズオン編』
+  https://zenn.dev/asa1984/books/nix-hands-on
 topics: ["nix"]
 published: true
 price: 0


### PR DESCRIPTION
[後編の config.yaml](https://github.com/asa1984/nix-zenn-articles/blob/affa9450ce83ec0b728f97f1012acd012cdf12fd/books/nix-hands-on/config.yaml) を参考に追加してみました 🙏🏻 

